### PR TITLE
Implements feature #8: add chart packaging feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.18</version>
+        <version>1.19</version>
         <type>jar</type>
       </dependency>
       
@@ -285,6 +285,10 @@
                 <url>http://static.javadoc.io/org.kamranzafar/jtar/2.3</url>
                 <location>${project.basedir}/src/main/javadoc/org.kamranzafar/jtar/2.3</location>
               </offlineLink>
+              <offlineLink>
+                <url>http://static.javadoc.io/org.yaml/snakeyaml/1.19</url>
+                <location>${project.basedir}/src/main/javadoc/org.yaml/snakeyaml/1.19</location>
+              </offlineLink>
             </offlineLinks>
           </configuration>
         </plugin>
@@ -375,6 +379,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
+            <project.build.directory>${project.build.directory}</project.build.directory>
             <org.slf4j.simpleLogger.log.io.fabric8>info</org.slf4j.simpleLogger.log.io.fabric8>
             <skipInstallationTest>${skipInstallationTest}</skipInstallationTest>
             <skipClusterTests>${skipClusterTests}</skipClusterTests>

--- a/src/main/java/org/microbean/helm/chart/AbstractArchiveChartWriter.java
+++ b/src/main/java/org/microbean/helm/chart/AbstractArchiveChartWriter.java
@@ -1,0 +1,254 @@
+/* -*- mode: Java; c-basic-offset: 2; indent-tabs-mode: nil; coding: utf-8-unix -*-
+ *
+ * Copyright © 2017 MicroBean.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.microbean.helm.chart;
+
+import java.io.IOException;
+
+import java.util.Objects;
+
+import com.google.protobuf.AnyOrBuilder;
+import com.google.protobuf.ByteString;
+
+import hapi.chart.ChartOuterClass.ChartOrBuilder;
+import hapi.chart.ConfigOuterClass.ConfigOrBuilder;
+import hapi.chart.MetadataOuterClass.MetadataOrBuilder;
+import hapi.chart.TemplateOuterClass.TemplateOrBuilder;
+
+/**
+ * A partial {@link AbstractChartWriter} whose implementations save
+ * {@link ChartOrBuilder} objects to a destination that can
+ * be considered an archive of some sort.
+ *
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
+ */
+public abstract class AbstractArchiveChartWriter extends AbstractChartWriter {
+
+
+  /*
+   * Constructors.
+   */
+
+
+  /**
+   * Creates a new {@link AbstractArchiveChartWriter}.
+   */
+  protected AbstractArchiveChartWriter() {
+    super();
+  }
+
+
+  /*
+   * Instance methods.
+   */
+
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The {@link AbstractArchiveChartWriter} implementation stores a
+   * {@link String} representing the required path layout under a
+   * "{@code path}" key in the supplied {@link Context}.</p>
+   */
+  @Override
+  protected void beginWrite(final Context context, final ChartOrBuilder parent, final ChartOrBuilder chartBuilder) throws IOException {
+    Objects.requireNonNull(context);
+    Objects.requireNonNull(chartBuilder);
+    if (parent == chartBuilder) {
+      throw new IllegalArgumentException("parent == chartBuilder");
+    }
+    final MetadataOrBuilder metadata = chartBuilder.getMetadataOrBuilder();
+    if (metadata == null) {
+      throw new IllegalArgumentException("chartBuilder", new IllegalStateException("chartBuilder.getMetadata() == null"));
+    }
+    final String chartName = metadata.getName();
+    if (chartName == null) {
+      throw new IllegalArgumentException("chartBuilder", new IllegalStateException("chartBuilder.getMetadata().getName() == null"));
+    }
+    
+    if (parent == null) {
+      context.put("path", new StringBuilder(chartName).append("/").toString());
+    } else {
+      final MetadataOrBuilder parentMetadata = parent.getMetadataOrBuilder();
+      if (parentMetadata == null) {
+        throw new IllegalArgumentException("parent", new IllegalStateException("parent.getMetadata() == null"));
+      }
+      final String parentChartName = parentMetadata.getName();
+      if (parentChartName == null) {
+        throw new IllegalArgumentException("parent", new IllegalStateException("parent.getMetadata().getName() == null"));
+      }      
+      context.put("path", new StringBuilder(context.get("path", String.class)).append("charts/").append(chartName).append("/").toString());
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The {@link AbstractArchiveChartWriter} implementation writes
+   * the {@linkplain #toYAML(Context, Object) YAML representation} of
+   * the supplied {@link MetadataOrBuilder} to an appropriate archive
+   * entry named {@code Chart.yaml} within the current chart path.</p>
+   *
+   * @exception NullPointerException if either {@code context} or
+   * {@code metadata} is {@code null}
+   */
+  @Override
+  protected void writeMetadata(final Context context, final MetadataOrBuilder metadata) throws IOException {
+    Objects.requireNonNull(context);
+    Objects.requireNonNull(metadata);
+
+    final String yaml = this.toYAML(context, metadata);
+    this.writeEntry(context, "Chart.yaml", yaml);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation writes the {@linkplain #toYAML(Context,
+   * Object) YAML representation} of the supplied {@link
+   * ConfigOrBuilder} to an appropriate archive entry named {@code
+   * values.yaml} within the current chart path.</p>
+   *
+   * @exception NullPointerException if {@code context} is {@code
+   * null}
+   */
+  @Override
+  protected void writeConfig(final Context context, final ConfigOrBuilder config) throws IOException {
+    Objects.requireNonNull(context);
+    
+    if (config != null) {
+      final String yaml = this.toYAML(context, config);
+      this.writeEntry(context, "values.yaml", yaml);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation writes the {@linkplain
+   * TemplateOrBuilder#getData() data} of the supplied {@link
+   * TemplateOrBuilder} to an appropriate archive entry named in part
+   * by the return value of the {@link TemplateOrBuilder#getName()}
+   * method within the current chart path.</p>
+   *
+   * @exception NullPointerException if {@code context} is {@code
+   * null}
+   */
+  @Override
+  protected void writeTemplate(final Context context, final TemplateOrBuilder template) throws IOException {
+    Objects.requireNonNull(context);
+    
+    if (template != null) {
+      final String templateName = template.getName();
+      if (templateName != null && !templateName.isEmpty()) {
+        final ByteString data = template.getData();
+        if (data != null && data.size() > 0) {
+          final String dataString = data.toStringUtf8();
+          assert dataString != null;
+          assert !dataString.isEmpty();
+          this.writeEntry(context, templateName, dataString);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation writes the {@linkplain
+   * AnyOrBuilder#getValue() contents} of the supplied {@link
+   * AnyOrBuilder} to an appropriate archive entry named in part by
+   * the return value of the {@link AnyOrBuilder#getTypeUrl()} method
+   * within the current chart path.</p>
+   *
+   * @exception NullPointerException if {@code context} is {@code
+   * null}
+   */
+  @Override
+  protected void writeFile(final Context context, final AnyOrBuilder file) throws IOException {
+    Objects.requireNonNull(context);
+    
+    if (file != null) {
+      final String fileName = file.getTypeUrl();
+      if (fileName != null && !fileName.isEmpty()) {
+        final ByteString data = file.getValue();
+        if (data != null && data.size() > 0) {
+          final String dataString = data.toStringUtf8();
+          assert dataString != null;
+          assert !dataString.isEmpty();
+          this.writeEntry(context, fileName, dataString);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation ensures that the current chart path,
+   * residing under the "{@code path}" key in the supplied {@link
+   * AbstractChartWriter.Context}, is reset properly.</p>
+   *
+   * @exception NullPointerException if either {@code context} or
+   * {@code chartBuilder} is {@code null}
+   */
+  @Override
+  protected void endWrite(final Context context, final ChartOrBuilder parent, final ChartOrBuilder chartBuilder) throws IOException {
+    Objects.requireNonNull(context);
+    Objects.requireNonNull(chartBuilder);
+    if (chartBuilder == parent) {
+      throw new IllegalArgumentException("chartBuilder == parent");
+    }
+    
+    if (parent == null) {
+      context.remove("path");
+    } else {
+      final String path = context.get("path", String.class);
+      assert path != null;
+      final int chartsIndex = path.lastIndexOf("/charts/");
+      assert chartsIndex > 0;
+      context.put("path", path.substring(0, chartsIndex + 1));
+    }
+  }
+
+  /**
+   * Writes the supplied {@code contents} to an appropriate archive
+   * entry that is expected to be suffixed with the supplied {@code
+   * path} in the context of the write operation described by the
+   * supplied {@link Context}.
+   *
+   * @param context the {@link Context} describing the write operation
+   * in effect; must not be {@code null}
+   *
+   * @param path the path within an abstract archive to write;
+   * interpreted as being relative to the current notional chart path,
+   * whatever that might be; must not be {@code null} or {@linkplain
+   * String#isEmpty() empty}
+   *
+   * @param contents the contents to write; must not be {@code null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if {@code context}, {@code path}
+   * or {@code contents} is {@code null}
+   *
+   * @exception IllegalArgumentException if {@code path} {@linkplain
+   * String#isEmpty() is empty}
+   */
+  protected abstract void writeEntry(final Context context, final String path, final String contents) throws IOException;
+
+}

--- a/src/main/java/org/microbean/helm/chart/AbstractChartWriter.java
+++ b/src/main/java/org/microbean/helm/chart/AbstractChartWriter.java
@@ -1,0 +1,786 @@
+/* -*- mode: Java; c-basic-offset: 2; indent-tabs-mode: nil; coding: utf-8-unix -*-
+ *
+ * Copyright © 2017 MicroBean.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.microbean.helm.chart;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import java.lang.reflect.Array;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
+import java.util.Set;
+
+import com.google.protobuf.AnyOrBuilder;
+
+import hapi.chart.ChartOuterClass.ChartOrBuilder;
+import hapi.chart.ConfigOuterClass.ConfigOrBuilder;
+import hapi.chart.MetadataOuterClass.MaintainerOrBuilder;
+import hapi.chart.MetadataOuterClass.MetadataOrBuilder;
+import hapi.chart.TemplateOuterClass.TemplateOrBuilder;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import org.yaml.snakeyaml.introspector.BeanAccess;
+import org.yaml.snakeyaml.introspector.MethodProperty;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.introspector.PropertyUtils;
+
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import org.yaml.snakeyaml.representer.Representer;
+
+/**
+ * An object capable of writing or serializing or otherwise
+ * representing a {@link ChartOrBuilder}.
+ *
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
+ *
+ * @see #write(ChartOuterClass.ChartOrBuilder)
+ */
+public abstract class AbstractChartWriter implements Closeable {
+
+
+  /*
+   * Constructors.
+   */
+
+
+  /**
+   * Creates a new {@link AbstractChartWriter}.
+   */
+  protected AbstractChartWriter() {
+    super();
+  }
+
+
+  /*
+   * Instance methods.
+   */
+
+  
+  /**
+   * Writes or serializes or otherwise represents the supplied {@link
+   * ChartOrBuilder}.
+   *
+   * @param chartBuilder the {@link ChartOrBuilder} to write; must not
+   * be {@code null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if {@code chartBuilder} is {@code
+   * null}
+   *
+   * @exception IllegalArgumentException if the {@link
+   * ChartOrBuilder#getMetadata()} method returns {@code null}, or if
+   * the {@link MetadataOrBuilder#getName()} method returns {@code
+   * null}, or if the {@link MetadataOrBuilder#getVersion()} method
+   * returns {@code null}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   *
+   * @see #write(Context, ChartOuterClass.ChartOrBuilder,
+   * ChartOuterClass.ChartOrBuilder)
+   */
+  public final void write(final ChartOrBuilder chartBuilder) throws IOException {
+    this.write(null, null, Objects.requireNonNull(chartBuilder));
+  }
+
+  /**
+   * Writes or serializes or otherwise represents the supplied {@code
+   * chartBuilder} as a subchart of the supplied {@code parent} (which
+   * may be, and often is, {@code null}).
+   *
+   * @param context the {@link Context} representing the write
+   * operation; may be {@code null}
+   *
+   * @param parent the {@link ChartOrBuilder} functioning as the
+   * parent chart; may be, and often is, {@code null}; must not be
+   * identical to the {@code chartBuilder} parameter value
+   *
+   * @param chartBuilder the {@link ChartOrBuilder} to actually write;
+   * must not be {@code null}; must not be identical to the {@code
+   * parent} parameter value
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if {@code chartBuilder} is {@code null}
+   *
+   * @exception IllegalArgumentException if {@code parent} is
+   * identical to {@code chartBuilder}, or if the {@link
+   * ChartOrBuilder#getMetadata()} method returns {@code null}, or if
+   * the {@link MetadataOrBuilder#getName()} method returns {@code
+   * null}, or if the {@link MetadataOrBuilder#getVersion()} method
+   * returns {@code null}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   *
+   * @see #beginWrite(Context, ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)
+   *
+   * @see #writeMetadata(Context, MetadataOrBuilder)
+   *
+   * @see #writeConfig(Context, ConfigOrBuilder)
+   *
+   * @see #writeTemplate(Context, TemplateOrBuilder)
+   *
+   * @see #writeFile(Context, AnyOrBuilder)
+   *
+   * @see #writeSubchart(Context, ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)
+   *
+   * @see #endWrite(Context, ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)
+   */
+  protected void write(Context context, final ChartOrBuilder parent, final ChartOrBuilder chartBuilder) throws IOException {
+    Objects.requireNonNull(chartBuilder);
+    if (parent == chartBuilder) {
+      throw new IllegalArgumentException("parent == chartBuilder");
+    }
+    final MetadataOrBuilder metadata = chartBuilder.getMetadataOrBuilder();
+    if (metadata == null) {
+      throw new IllegalArgumentException("chartBuilder", new IllegalStateException("chartBuilder.getMetadata() == null"));
+    } else if (metadata.getName() == null) {
+      throw new IllegalArgumentException("chartBuilder", new IllegalStateException("chartBuilder.getMetadata().getName() == null"));
+    } else if (metadata.getVersion() == null) {
+      throw new IllegalArgumentException("chartBuilder", new IllegalStateException("chartBuilder.getMetadata().getVersion() == null"));
+    }
+
+    if (context == null) {
+      final Map<Object, Object> map = new HashMap<>(13);
+      context = new Context() {
+          @Override
+          public final <T> T get(final Object key, final Class<T> type) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(type);
+            return type.cast(map.get(key));
+          }
+          
+          @Override
+          public final void put(final Object key, final Object value) {
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
+            map.put(key, value);
+          }
+          
+          @Override
+          public final boolean containsKey(final Object key) {
+            return map.containsKey(key);
+          }
+
+          @Override
+          public final void remove(final Object key) {
+            map.remove(key);
+          }
+        };
+    }
+
+    this.beginWrite(context, parent, chartBuilder);
+    
+    this.writeMetadata(context, metadata);
+
+    this.writeConfig(context, chartBuilder.getValuesOrBuilder());
+
+    final Collection<? extends TemplateOrBuilder> templates = chartBuilder.getTemplatesOrBuilderList();
+    if (templates != null && !templates.isEmpty()) {
+      for (final TemplateOrBuilder template : templates) {
+        this.writeTemplate(context, template);
+      }
+    }
+
+    final Collection<? extends AnyOrBuilder> files = chartBuilder.getFilesOrBuilderList();
+    if (files != null && !files.isEmpty()) {
+      for (final AnyOrBuilder file : files) {
+        this.writeFile(context, file);
+      }
+    }
+
+    final Collection<? extends ChartOrBuilder> subcharts = chartBuilder.getDependenciesOrBuilderList();
+    if (subcharts != null && !subcharts.isEmpty()) {
+      for (final ChartOrBuilder subchart : subcharts) {
+        if (subchart != null) {
+          this.writeSubchart(context, chartBuilder, subchart);
+        }
+      }
+    }
+
+    this.endWrite(context, parent, chartBuilder);
+    
+  }
+
+  /**
+   * Creates and returns a new {@link Yaml} instance for (optional)
+   * use in writing {@link ConfigOrBuilder} and {@link
+   * MetadataOrBuilder} objects.
+   *
+   * <p>This method never returns {@code null}.</p>
+   *
+   * <p>Overrides of this method must not return {@code null}.</p>
+   *
+   * <p>Behavior is undefined if overrides of this method interact
+   * with other methods defined by this class.</p>
+   *
+   * @return a non-{@code null} {@link Yaml} instance
+   */
+  protected Yaml createYaml() {
+    final Representer representer = new TerseRepresenter();
+    representer.setPropertyUtils(new CustomPropertyUtils());
+    final DumperOptions options = new DumperOptions();
+    options.setAllowReadOnlyProperties(true);
+    return new Yaml(new Constructor(), representer, options);
+  }
+
+  /**
+   * Marshals the supplied {@link Object} to YAML in the context of
+   * the supplied {@link Context} and returns the result.
+   *
+   * <p>This method never returns {@code null}.</p>
+   *
+   * <p>This method may call the {@link #createYaml()} method.</p>
+   */
+  protected final String toYAML(final Context context, final Object data) throws IOException {
+    Objects.requireNonNull(context);
+    Yaml yaml = context.get(Yaml.class.getName(), Yaml.class);
+    if (yaml == null) {
+      yaml = this.createYaml();
+      if (yaml == null) {
+        throw new IllegalStateException("createYaml() == null");
+      }
+      context.put(Yaml.class.getName(), yaml);
+    }
+    return yaml.dumpAsMap(data);
+  }
+
+  /**
+   * A callback method invoked when the {@link #write(Context,
+   * ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)}
+   * method has been invoked.
+   *
+   * <p>The default implementation of this method does nothing.</p>
+   *
+   * @param context the {@link Context} representing the write
+   * operation; must not be {@code null}
+   *
+   * @param parent the {@link ChartOrBuilder} functioning as the
+   * parent chart; may be, and often is, {@code null}; must not be
+   * identical to the {@code chartBuilder} parameter value
+   *
+   * @param chartBuilder the {@link ChartOrBuilder} to actually write;
+   * must not be {@code null}; must not be identical to the {@code
+   * parent} parameter value
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if either {@code context} or {@code chartBuilder} is {@code null}
+   *
+   * @exception IllegalArgumentException if {@code parent} is
+   * identical to {@code chartBuilder}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   * from this method for some reason
+   *
+   */
+  protected void beginWrite(final Context context, final ChartOrBuilder parent, final ChartOrBuilder chartBuilder) throws IOException {
+    Objects.requireNonNull(context);
+    Objects.requireNonNull(chartBuilder);
+    if (parent == chartBuilder) {
+      throw new IllegalArgumentException("parent == chartBuilder");
+    }
+  }
+
+  /**
+   * A callback method invoked when the {@link #write(Context,
+   * ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)} method has been invoked and it
+   * is time to write a relevant {@link MetadataOrBuilder} object.
+   *
+   * @param context the {@link Context} representing the write
+   * operation; must not be {@code null}
+   *
+   * @param metadata the {@link MetadataOrBuilder} to write; must not
+   * be {@code null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if either {@code context} or
+   * {@code metadata} is {@code null}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   * from this method
+   */
+  protected abstract void writeMetadata(final Context context, final MetadataOrBuilder metadata) throws IOException;
+
+  /**
+   * A callback method invoked when the {@link #write(Context,
+   * ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)} method has been invoked and it
+   * is time to write a relevant {@link ConfigOrBuilder} object.
+   *
+   * @param context the {@link Context} representing the write
+   * operation; must not be {@code null}
+   *
+   * @param config the {@link ConfigOrBuilder} to write; must not
+   * be {@code null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if either {@code context} or
+   * {@code config} is {@code null}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   * from this method
+   */
+  protected abstract void writeConfig(final Context context, final ConfigOrBuilder config) throws IOException;
+
+  /**
+   * A callback method invoked when the {@link #write(Context,
+   * ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)} method has been invoked and it
+   * is time to write a relevant {@link TemplateOrBuilder} object.
+   *
+   * @param context the {@link Context} representing the write
+   * operation; must not be {@code null}
+   *
+   * @param template the {@link TemplateOrBuilder} to write; must not
+   * be {@code null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if either {@code context} or
+   * {@code template} is {@code null}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   * from this method for some reason
+   */
+  protected abstract void writeTemplate(final Context context, final TemplateOrBuilder template) throws IOException;
+
+  /**
+   * A callback method invoked when the {@link #write(Context,
+   * ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)} method has been invoked and it
+   * is time to write a relevant {@link AnyOrBuilder} object
+   * (representing an otherwise undifferentiated Helm chart file).
+   *
+   * @param context the {@link Context} representing the write
+   * operation; must not be {@code null}
+   *
+   * @param file the {@link AnyOrBuilder} to write; must not be {@code
+   * null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if either {@code context} or
+   * {@code file} is {@code null}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   * from this method for some reason
+   */
+  protected abstract void writeFile(final Context context, final AnyOrBuilder file) throws IOException;
+
+  /**
+   * A callback method invoked when the {@link #write(Context,
+   * ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)} method has been invoked and it
+   * is time to write a relevant {@link ChartOrBuilder} object
+   * (representing a subchart within an encompassing parent Helm
+   * chart).
+   *
+   * <p>The default implementation of this method calls the {@link
+   * #write(Context, ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)} method.</p>
+   *
+   * @param context the {@link Context} representing the write
+   * operation; must not be {@code null}
+   *
+   * @param parent the {@link ChartOrBuilder} representing the Helm
+   * chart that parents the {@code subchart} parameter value; must not
+   * be {@code null}
+   *
+   * @param subchart the {@link ChartOrBuilder} representing the
+   * subchart to write; must not be {@code null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if either {@code context} or
+   * {@code parent} or {@code subchart} is {@code null}
+   *
+   * @exception IllegalArgumentException if {@code parent} is
+   * identical to {@code subchart}, or if the {@link
+   * ChartOrBuilder#getMetadata()} method returns {@code null} when
+   * invoked on either non-{@code null} {@link ChartOrBuilder}, or if
+   * the {@link MetadataOrBuilder#getName()} method returns {@code
+   * null}, or if the {@link MetadataOrBuilder#getVersion()} method
+   * returns {@code null}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   * from this method for some reason
+   *
+   * @see #write(Context, ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)
+   */
+  protected void writeSubchart(final Context context, final ChartOrBuilder parent, final ChartOrBuilder subchart) throws IOException {
+    this.write(Objects.requireNonNull(context), Objects.requireNonNull(parent), Objects.requireNonNull(subchart));
+  }
+
+  /**
+   * A callback method invoked when the {@link #write(Context,
+   * ChartOuterClass.ChartOrBuilder, ChartOuterClass.ChartOrBuilder)} method has been invoked and it
+   * is time to end the write operation.
+   *
+   * <p>The default implementation of this method does nothing.</p>
+   *
+   * @param context the {@link Context} representing the write
+   * operation; must not be {@code null}
+   *
+   * @param parent the {@link ChartOrBuilder} representing the Helm
+   * chart that parents the {@code chartBuilder} parameter value; may be,
+   * and often is, {@code null}
+   *
+   * @param chartBuilder the {@link ChartOrBuilder} representing the
+   * chart currently involved in the write operation; must not be
+   * {@code null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if either {@code context} or
+   * {@code chartBuilder} is {@code null}
+   *
+   * @exception IllegalArgumentException if {@code parent} is
+   * identical to {@code chartBuilder}
+   *
+   * @exception IllegalStateException if a subclass has overridden the
+   * {@link #createYaml()} method to return {@code null} and calls it
+   * from this method for some reason
+   */
+  protected void endWrite(final Context context, final ChartOrBuilder parent, final ChartOrBuilder chartBuilder) throws IOException {
+    Objects.requireNonNull(context);
+    Objects.requireNonNull(chartBuilder);
+    if (parent == chartBuilder) {
+      throw new IllegalArgumentException("parent == chartBuilder");
+    }
+  }
+
+
+  /*
+   * Inner and nested classes.
+   */
+
+
+  /**
+   * A class representing the state of a write operation.
+   *
+   * @author <a href="https://about.me/lairdnelson"
+   * target="_parent">Laird Nelson</a>
+   */
+  protected static abstract class Context {
+
+
+    /*
+     * Constructors.
+     */
+
+
+    /**
+     * Creates a new {@link Context}.
+     */
+    private Context() {
+      super();
+    }
+
+
+    /*
+     * Instance methods.
+     */
+
+    /**
+     * Returns the object indexed under the supplied {@code key}, if
+     * any, {@linkplain Class#cast(Object) cast to the proper
+     * <code>Class</code>}.
+     *
+     * <p>Implementations of this method may return {@code null}.</p>
+     *
+     * @param <T> the type of object expected
+     *
+     * @param key the key under which something is hopefully stored;
+     * may be {@code null}
+     *
+     * @param type the {@link Class} to cast the result to; must not
+     * be {@code null}
+     *
+     * @return the object in question, or {@code null}
+     *
+     * @exception NullPointerException if {@code type} is {@code null}
+     *
+     * @see #put(Object, Object)
+     */
+    public abstract <T> T get(final Object key, final Class<T> type);
+
+    /**
+     * Stores the supplied {@code value} under the supplied {@code key}.
+     *
+     * @param key the key under which the supplied {@code value} will
+     * be stored; may be {@code null}
+     *
+     * @param value the object to store; may be {@code null}
+     *
+     * @see #get(Object, Class)
+     */
+    public abstract void put(final Object key, final Object value);
+
+    /**
+     * Returns {@code true} if this {@link Context} implementation
+     * contains an object indexed under an {@link Object} {@linkplain
+     * Object#equals(Object) equal to} the supplied {@code key}.
+     *
+     * @param key the key in question; may be {@code null}
+     *
+     * @return {@code true} if this {@link Context} implementation
+     * contains an object indexed under an {@link Object} {@linkplain
+     * Object#equals(Object) equal to} the supplied {@code key};
+     * {@code false} otherwise
+     */
+    public abstract boolean containsKey(final Object key);
+
+    /**
+     * Removes any object indexed under an {@link Object} {@linkplain
+     * Object#equals(Object) equal to} the supplied {@code key}.
+     *
+     * @param key the key in question; may be {@code null}
+     */
+    public abstract void remove(final Object key);
+    
+  }
+
+  /**
+   * A {@link Representer} that attempts not to output default values
+   * or YAML tags.
+   *
+   * @author <a href="https://about.me/lairdnelson"
+   * target="_parent">Laird Nelson</a>
+   */
+  private static final class TerseRepresenter extends Representer {
+
+
+    /*
+     * Constructors.
+     */
+
+
+    /**
+     * Creates a new {@link TerseRepresenter}.
+     */
+    private TerseRepresenter() {
+      super();
+    }
+
+
+    /*
+     * Instance methods.
+     */
+
+
+    /**
+     * Represents a Java bean normally, but without any YAML tag
+     * information.
+     *
+     * @param properties a {@link Set} of {@link Property} instances
+     * indicating what facets of the supplied {@code bean} should be
+     * represented; ignored by this implementation
+     *
+     * @param bean the {@link Object} to represent; may be {@code null}
+     *
+     * @return the result of invoking {@link
+     * Representer#representJavaBean(Set, Object)}, but after adding
+     * {@link Tag#MAP} as a {@linkplain Representer#addClassTag(Class,
+     * Tag) class tag} for the supplied {@code bean}'s class
+     */
+    @Override
+    protected final MappingNode representJavaBean(final Set<Property> properties, final Object bean) {
+      if (bean != null) {
+        final Class<?> beanClass = bean.getClass();
+        if (this.getTag(beanClass, null) == null) {
+          this.addClassTag(beanClass, Tag.MAP);
+        }
+      }
+      return super.representJavaBean(properties, bean);      
+    }
+
+    /**
+     * Overrides the {@link
+     * Representer#representJavaBeanProperty(Object, Property, Object,
+     * Tag)} method to return {@code null} when the given property
+     * value can be omitted from its YAML representation without loss
+     * of information.
+     *
+     * @param bean the Java bean whose property value is being
+     * represented; may be {@code null}
+     *
+     * @param property the {@link Property} whose value is being
+     * represented; may be {@code null}
+     *
+     * @param value the value being represented; may be {@code null}
+     *
+     * @param tag the {@link Tag} in effect; may be {@code null}
+     *
+     * @return {@code null} or the result of invoking the {@link
+     * Representer#representJavaBeanProperty(Object, Property, Object,
+     * Tag)} method with the supplied values
+     */
+    @Override
+    protected final NodeTuple representJavaBeanProperty(final Object bean, final Property property, final Object value, final Tag tag) {
+      final NodeTuple returnValue;
+      if (value == null || value.equals(Boolean.FALSE)) {
+        returnValue = null;
+      } else if (value instanceof CharSequence) {
+        if (((CharSequence)value).length() <= 0) {
+          returnValue = null;
+        } else {
+          returnValue = super.representJavaBeanProperty(bean, property, value, tag);
+        }
+      } else if (value instanceof Collection) {
+        if (((Collection<?>)value).isEmpty()) {
+          returnValue = null;
+        } else {
+          returnValue = super.representJavaBeanProperty(bean, property, value, tag);
+        }
+      } else if (value instanceof Map) {
+        if (((Map<?, ?>)value).isEmpty()) {
+          returnValue = null;
+        } else {
+          returnValue = super.representJavaBeanProperty(bean, property, value, tag);
+        }
+      } else if (value.getClass().isArray()) {
+        if (Array.getLength(value) <= 0) {
+          returnValue = null;
+        } else {
+          returnValue = super.representJavaBeanProperty(bean, property, value, tag);
+        }
+      } else {
+        returnValue = super.representJavaBeanProperty(bean, property, value, tag);
+      }
+      return returnValue;
+    }
+    
+  }
+
+  /**
+   * A {@link PropertyUtils} that knows how to represent certain
+   * properties of certain Helm-related objects for the purposes of
+   * serialization to YAML.
+   *
+   * @author <a href="https://about.me/lairdnelson"
+   * target="_parent">Laird Nelson</a>
+   */
+  private static final class CustomPropertyUtils extends PropertyUtils {
+
+
+    /*
+     * Constructors.
+     */
+
+
+    /**
+     * Creates a new {@link CustomPropertyUtils}.
+     */
+    private CustomPropertyUtils() {
+      super();
+    }
+
+
+    /*
+     * Instance methods.
+     */
+    
+
+    /**
+     * Returns a {@link Set} of {@link Property} instances that will
+     * represent Java objects of the supplied {@code type} during YAML
+     * serialization.
+     *
+     * <p>This implementation overrides the {@link
+     * PropertyUtils#createPropertySet(Class, BeanAccess)} method to
+     * build explicit representations for {@link MetadataOrBuilder},
+     * {@link MaintainerOrBuilder} and {@link ConfigOrBuilder}
+     * interfaces.</p>
+     *
+     * @param type a {@link Class} for which a {@link Set} of
+     * representational {@link Property} instances should be returned;
+     * may be {@code null}
+     *
+     * @param beanAccess ignored by this implementation
+     *
+     * @return a {@link Set} of {@link Property} instances; never
+     * {@code null}
+     */
+    @Override
+    protected final Set<Property> createPropertySet(final Class<?> type, final BeanAccess beanAccess) {
+      final Set<Property> returnValue;
+      if (MetadataOrBuilder.class.isAssignableFrom(type)) {
+        returnValue = new TreeSet<>();
+        try {
+          returnValue.add(new MethodProperty(new PropertyDescriptor("apiVersion", type, "getApiVersion", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("appVersion", type, "getAppVersion", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("condition", type, "getCondition", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("deprecated", type, "getDeprecated", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("description", type, "getDescription", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("engine", type, "getEngine", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("home", type, "getHome", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("icon", type, "getIcon", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("keywords", type, "getKeywordsList", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("maintainers", type, "getMaintainersOrBuilderList", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("name", type, "getName", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("sources", type, "getSourcesList", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("tags", type, "getTags", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("tillerVersion", type, "getTillerVersion", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("version", type, "getVersion", null)));
+        } catch (final IntrospectionException introspectionException) {
+          throw new IllegalStateException(introspectionException.getMessage(), introspectionException);
+        }
+      } else if (MaintainerOrBuilder.class.isAssignableFrom(type)) {
+        returnValue = new TreeSet<>();
+        try {
+          returnValue.add(new MethodProperty(new PropertyDescriptor("name", type, "getName", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("email", type, "getEmail", null)));
+        } catch (final IntrospectionException introspectionException) {
+          throw new IllegalStateException(introspectionException.getMessage(), introspectionException);
+        }
+      } else if (ConfigOrBuilder.class.isAssignableFrom(type)) {
+        returnValue = new TreeSet<>();
+        try {
+          returnValue.add(new MethodProperty(new PropertyDescriptor("raw", type, "getRaw", null)));
+        } catch (final IntrospectionException introspectionException) {
+          throw new IllegalStateException(introspectionException.getMessage(), introspectionException);
+        }
+      } else {
+        returnValue = super.createPropertySet(type, beanAccess);
+      }
+      return returnValue;
+    }
+    
+  }
+  
+}

--- a/src/main/java/org/microbean/helm/chart/TapeArchiveChartWriter.java
+++ b/src/main/java/org/microbean/helm/chart/TapeArchiveChartWriter.java
@@ -1,0 +1,157 @@
+/* -*- mode: Java; c-basic-offset: 2; indent-tabs-mode: nil; coding: utf-8-unix -*-
+ *
+ * Copyright © 2017 MicroBean.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.microbean.helm.chart;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import com.google.protobuf.AnyOrBuilder;
+import com.google.protobuf.ByteString;
+
+import hapi.chart.ChartOuterClass.Chart;
+import hapi.chart.ChartOuterClass.ChartOrBuilder;
+import hapi.chart.ConfigOuterClass.ConfigOrBuilder;
+import hapi.chart.MetadataOuterClass.Metadata;
+import hapi.chart.MetadataOuterClass.MetadataOrBuilder;
+import hapi.chart.TemplateOuterClass.Template;
+import hapi.chart.TemplateOuterClass.TemplateOrBuilder;
+
+import org.kamranzafar.jtar.TarEntry;
+import org.kamranzafar.jtar.TarHeader;
+import org.kamranzafar.jtar.TarOutputStream;
+
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * An {@link AbstractArchiveChartWriter} that saves {@link
+ * ChartOrBuilder} objects to a {@linkplain
+ * #TapeArchiveChartWriter(OutputStream) supplied
+ * <code>OutputStream</code>} in <a
+ * href="https://www.gnu.org/software/tar/manual/html_node/Standard.html">TAR
+ * format</a>, using a {@link TarOutputStream} internally.
+ *
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
+ */
+public class TapeArchiveChartWriter extends AbstractArchiveChartWriter {
+
+
+  /*
+   * Instance fields.
+   */
+
+
+  /**
+   * The {@link TarOutputStream} to write to.
+   *
+   * <p>This field is never {@code null}.</p>
+   *
+   * @see #TapeArchiveChartWriter(OutputStream)
+   */
+  private final TarOutputStream outputStream;
+
+
+  /*
+   * Constructors.
+   */
+
+
+  /**
+   * Creates a new {@link TapeArchiveChartWriter}.
+   *
+   * @param outputStream the {@link OutputStream} to write to; must
+   * not be {@code null} and should be buffered at some level
+   *
+   * @see
+   * AbstractArchiveChartWriter#AbstractArchiveChartWriter()
+   *
+   * @see TarOutputStream#TarOutputStream(OutputStream)
+   */
+  public TapeArchiveChartWriter(final OutputStream outputStream) {
+    super();
+    Objects.requireNonNull(outputStream);
+    this.outputStream = new TarOutputStream(outputStream);
+  }
+
+
+  /*
+   * Instance methods.
+   */
+  
+
+  /**
+   * Creates a new {@link TarHeader} and a {@link TarEntry} wrapping
+   * it and writes it and the supplied {@code contents} to the
+   * underlying {@link TarOutputStream}.
+   *
+   * @param context the {@link Context} describing the write operation
+   * in effect; must not be {@code null}
+   *
+   * @param path the path within a tape archive to write; interpreted
+   * as being relative to the current chart path; must not be {@code
+   * null} or {@linkplain String#isEmpty() empty}
+   *
+   * @param contents the contents to write; must not be {@code null}
+   *
+   * @exception IOException if a write error occurs
+   *
+   * @exception NullPointerException if {@code context}, {@code path}
+   * or {@code contents} is {@code null}
+   *
+   * @exception IllegalArgumentException if {@code path} {@linkplain
+   * String#isEmpty() is empty}
+   */
+  @Override
+  protected void writeEntry(final Context context, final String path, final String contents) throws IOException {
+    Objects.requireNonNull(context);
+    Objects.requireNonNull(path);
+    Objects.requireNonNull(contents);
+    if (path.isEmpty()) {
+      throw new IllegalArgumentException("path", new IllegalStateException("path.isEmpty()"));
+    }
+
+    final byte[] contentsBytes = contents.getBytes(StandardCharsets.UTF_8);
+    final long size = contentsBytes.length;
+    final TarHeader tarHeader = TarHeader.createHeader(new StringBuilder(context.get("path", String.class)).append(path).toString(), size, System.currentTimeMillis(), false, 0755);
+    final TarEntry tarEntry = new TarEntry(tarHeader);
+    this.outputStream.putNextEntry(tarEntry);
+    this.outputStream.write(contentsBytes);
+    this.outputStream.flush();
+  }
+
+  /**
+   * Closes this {@link TapeArchiveChartWriter} by closing its
+   * underlying {@link TarOutputStream}.  This {@link
+   * TapeArchiveChartWriter} cannot be used again.
+   *
+   * @exception IOException if there was a problem closing the
+   * underlying {@link TarOutputStream}
+   */
+  @Override
+  public void close() throws IOException {
+    this.outputStream.close();
+  }
+  
+}

--- a/src/main/javadoc/org.yaml/snakeyaml/1.19/package-list
+++ b/src/main/javadoc/org.yaml/snakeyaml/1.19/package-list
@@ -1,0 +1,17 @@
+org.yaml.snakeyaml
+org.yaml.snakeyaml.composer
+org.yaml.snakeyaml.constructor
+org.yaml.snakeyaml.emitter
+org.yaml.snakeyaml.error
+org.yaml.snakeyaml.events
+org.yaml.snakeyaml.extensions.compactnotation
+org.yaml.snakeyaml.introspector
+org.yaml.snakeyaml.nodes
+org.yaml.snakeyaml.parser
+org.yaml.snakeyaml.reader
+org.yaml.snakeyaml.representer
+org.yaml.snakeyaml.resolver
+org.yaml.snakeyaml.scanner
+org.yaml.snakeyaml.serializer
+org.yaml.snakeyaml.tokens
+org.yaml.snakeyaml.util

--- a/src/test/java/org/microbean/helm/chart/TestTapeArchiveChartWriter.java
+++ b/src/test/java/org/microbean/helm/chart/TestTapeArchiveChartWriter.java
@@ -1,0 +1,83 @@
+/* -*- mode: Java; c-basic-offset: 2; indent-tabs-mode: nil; coding: utf-8-unix -*-
+ *
+ * Copyright © 2017 MicroBean.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.microbean.helm.chart;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+
+import java.net.URI;
+import java.net.URL;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.zip.GZIPOutputStream;
+
+import hapi.chart.ChartOuterClass.ChartOrBuilder;
+import hapi.chart.ChartOuterClass.Chart;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class TestTapeArchiveChartWriter {
+
+  private ChartOrBuilder chart;
+
+  private Path buildDirectory;
+  
+  @Before
+  public void setUp() throws IOException {
+    // Chart is arbitrary, but it does have subcharts in it, which exercise some tricky logic
+    final URI uri = URI.create("https://kubernetes-charts.storage.googleapis.com/wordpress-0.6.6.tgz");
+    assertNotNull(uri);
+    final URL url = uri.toURL();
+    assertNotNull(url);
+    try (final URLChartLoader loader = new URLChartLoader()) {
+      this.chart = loader.load(url);
+    }
+    assertNotNull(this.chart);
+    final Path buildDirectory = Paths.get(System.getProperty("project.build.directory"));
+    assertNotNull(buildDirectory);
+    assertTrue(Files.isDirectory(buildDirectory));
+    assertTrue(Files.isWritable(buildDirectory));
+    this.buildDirectory = buildDirectory;
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    
+  }
+
+  @Test
+  public void testWrite() throws IOException {
+    final Path chartPath = this.buildDirectory.resolve("TestTapeArchiveChartWriter.tar.gz");
+    assertNotNull(chartPath);
+    try (final TapeArchiveChartWriter writer = new TapeArchiveChartWriter(new BufferedOutputStream(new GZIPOutputStream(Files.newOutputStream(chartPath))))) {
+      writer.write(this.chart);
+    }
+    assertTrue(Files.isRegularFile(chartPath));
+    Files.delete(chartPath);    
+  }
+
+}


### PR DESCRIPTION
This pull request first and foremost helps me get familiar with Github's workflow (I'm used to Gitlab, which is a bit more seamless and issue-driven).  I will probably make a hash out of things as a learn, so you have been warned.

This pull request adds the notion of an `AbstractChartWriter` and some subclasses to enable the serialization of `hapi.chart.ChartOuterClass.ChartOrBuilder` instances.