### PR TITLE
Fixes #90 and fixes #62.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ to do these operations.
 
 The microbean-helm project's version number tracks the Helm and Tiller
 release it works with, together with its own version semantics.  For
-example, a microbean-helm version of `2.7.2.1.0.0` means that the Helm
-version it tracks is `2.7.2` and the (SemVer-compatible) version of
+example, a microbean-helm version of `2.8.1.1.0.0` means that the Helm
+version it tracks is `2.8.1` and the (SemVer-compatible) version of
 the non-generated code that is part of _this_ project is `1.0.0`.
 
 # Installation
@@ -32,7 +32,7 @@ like this:
       <groupId>org.microbean</groupId>
       <artifactId>microbean-helm</artifactId>
       <!-- See http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.microbean%22%20AND%20a%3A%22microbean-helm%22 for available releases. -->
-      <version>2.7.2.1.0.0</version>
+      <version>2.8.1.1.0.0</version>
       <type>jar</type>
     </dependency>
     

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.microbean</groupId>
   <artifactId>microbean-helm</artifactId>
-  <version>2.7.2.1.0.1-SNAPSHOT</version>
+  <version>2.8.1.1.0.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.microbean</groupId>
@@ -373,7 +373,7 @@
               <checkoutDirectory>${project.build.directory}/generated-sources/helm</checkoutDirectory>
               <connectionUrl>scm:git:https://github.com/kubernetes/helm.git</connectionUrl>
               <includes>_proto/hapi/**</includes>
-              <scmVersion>v2.7.2</scmVersion>
+              <scmVersion>v2.8.1</scmVersion>
               <scmVersionType>tag</scmVersionType>
             </configuration>
           </execution>

--- a/src/main/java/org/microbean/helm/Tiller.java
+++ b/src/main/java/org/microbean/helm/Tiller.java
@@ -77,7 +77,7 @@ public class Tiller implements ConfigAware<Config>, Closeable {
    *
    * <p>This field is never {@code null}.</p>
    */
-  public static final String VERSION = "2.7.2";
+  public static final String VERSION = "2.8.1";
 
   /**
    * The Kubernetes namespace into which Tiller server instances are

--- a/src/main/java/org/microbean/helm/TillerInstaller.java
+++ b/src/main/java/org/microbean/helm/TillerInstaller.java
@@ -108,7 +108,7 @@ public class TillerInstaller {
   /**
    * The version of Tiller to install.
    */
-  public static final String VERSION = "2.7.2";
+  public static final String VERSION = "2.8.1";
 
   /*
    * Derivative static fields.

--- a/src/main/java/org/microbean/helm/chart/AbstractChartWriter.java
+++ b/src/main/java/org/microbean/helm/chart/AbstractChartWriter.java
@@ -781,8 +781,9 @@ public abstract class AbstractChartWriter implements Closeable {
       } else if (MaintainerOrBuilder.class.isAssignableFrom(type)) {
         returnValue = new TreeSet<>();
         try {
-          returnValue.add(new MethodProperty(new PropertyDescriptor("name", type, "getName", null)));
           returnValue.add(new MethodProperty(new PropertyDescriptor("email", type, "getEmail", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("name", type, "getName", null)));
+          returnValue.add(new MethodProperty(new PropertyDescriptor("url", type, "getUrl", null)));
         } catch (final IntrospectionException introspectionException) {
           throw new IllegalStateException(introspectionException.getMessage(), introspectionException);
         }

--- a/src/main/java/org/microbean/helm/package-info.java
+++ b/src/main/java/org/microbean/helm/package-info.java
@@ -26,7 +26,7 @@
  *
  * @see org.microbean.helm.ReleaseManager
  */
-@Version("2.7.2.1.0.0")
+@Version("2.8.1.1.0.0")
 package org.microbean.helm;
 
 import org.microbean.development.annotation.Version;


### PR DESCRIPTION
This is a first cut at tiller 2.8.1 support.

I'll file follow on issues to pick up some low-priority changes to track the `helm` client functionality, such as [enhancements to `helm init --upgrade`](https://github.com/kubernetes/helm/commit/2b2b994092fc7b8407dd8403c673844721ccd929) but this pull request should allow usage of the Tiller 2.8.1 APIs.