### PR TITLE
Document that os-maven-plugin is needed to resolve dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ To install microBean Helm, simply include it as a dependency in your
 project.  If you're using Maven, the dependency stanza should look
 like this:
 
+```
+    <build>
+      <extensions>
+        <extension>
+          <groupId>kr.motd.maven</groupId>
+          <!-- needed to resolve os-dependent classifiers -->
+          <artifactId>os-maven-plugin</artifactId>
+          <version>1.5.0.Final</version>
+        </extension>
+      </extensions>
+    </build>
+
     <dependency>
       <groupId>org.microbean</groupId>
       <artifactId>microbean-helm</artifactId>
@@ -35,7 +47,8 @@ like this:
       <version>2.8.2.1.1.0</version>
       <type>jar</type>
     </dependency>
-    
+```
+
 Releases are [available in Maven Central][10].  Snapshots are available
 in [Sonatype Snapshots][11].
 


### PR DESCRIPTION
The main pom.xml of microbean-helm depends on
io.netty:netty-tcnative-boringssl-static:jar:${os.detected.classifier}
where the os.detected.classifier property is computed by the os-maven-plugin.
This commit updates the README.md to reflect the need of the
os-maven-plugin.