### PR TITLE
Abstract ManagedChannel Creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 nbactions.xml
 src/site/markdown/*.html
 target/
+.idea
+*.iml

--- a/src/main/java/org/microbean/helm/DefaultManagedChannelFactory.java
+++ b/src/main/java/org/microbean/helm/DefaultManagedChannelFactory.java
@@ -1,0 +1,61 @@
+package org.microbean.helm;
+
+import io.fabric8.kubernetes.client.LocalPortForward;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.net.InetAddress;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.microbean.development.annotation.Issue;
+
+/**
+ * A default implementation of the {@link ManagedChannelFactory} that creates a {@link ManagedChannel}
+ * from a {@link LocalPortForward}.
+ *
+ * Allows additional customization of the {@link ManagedChannelBuilder} by supplying a
+ * {@link ManagedChannelConfigurer} to the constructor.
+ */
+public class DefaultManagedChannelFactory implements ManagedChannelFactory {
+
+  private static final ManagedChannelConfigurer NOOP_CONFIGURER = (builder) -> {};
+  private final ManagedChannelConfigurer configurer;
+
+  public DefaultManagedChannelFactory() {
+    this.configurer = NOOP_CONFIGURER;
+  }
+
+  /**
+   * @param configurer a {@link ManagedChannelConfigurer} to allow overriding of the default
+   * configuration of the {@link ManagedChannel}
+   *
+   * @throws NullPointerException if the configurer is null
+   */
+  public DefaultManagedChannelFactory(final ManagedChannelConfigurer configurer) {
+    Objects.requireNonNull(configurer);
+    this.configurer = configurer;
+  }
+
+  @Issue(id = "42", uri = "https://github.com/microbean/microbean-helm/issues/42")
+  @Override public ManagedChannel create(final LocalPortForward portForward) {
+    Objects.requireNonNull(portForward);
+    @Issue(id = "43", uri = "https://github.com/microbean/microbean-helm/issues/43")
+    final InetAddress localAddress = portForward.getLocalAddress();
+    if (localAddress == null) {
+      throw new IllegalArgumentException("portForward",
+          new IllegalStateException("portForward.getLocalAddress() == null"));
+    }
+    final String hostAddress = localAddress.getHostAddress();
+    if (hostAddress == null) {
+      throw new IllegalArgumentException("portForward",
+          new IllegalStateException("portForward.getLocalAddress().getHostAddress() == null"));
+    }
+    final ManagedChannelBuilder builder =
+        ManagedChannelBuilder.forAddress(hostAddress, portForward.getLocalPort())
+            .idleTimeout(5L, TimeUnit.SECONDS)
+            .keepAliveTime(30L, TimeUnit.SECONDS)
+            .maxInboundMessageSize(Tiller.MAX_MESSAGE_SIZE)
+            .usePlaintext(true);
+    configurer.configure(builder);
+    return builder.build();
+  }
+}

--- a/src/main/java/org/microbean/helm/ManagedChannelConfigurer.java
+++ b/src/main/java/org/microbean/helm/ManagedChannelConfigurer.java
@@ -1,0 +1,11 @@
+package org.microbean.helm;
+
+import io.grpc.ManagedChannelBuilder;
+
+/**
+ * An interface whose implementations configure options on the supplied
+ * {@link ManagedChannelBuilder} to override defaults.
+ */
+public interface ManagedChannelConfigurer {
+  void configure(final ManagedChannelBuilder<?> managedChannelBuilder);
+}

--- a/src/main/java/org/microbean/helm/ManagedChannelFactory.java
+++ b/src/main/java/org/microbean/helm/ManagedChannelFactory.java
@@ -1,0 +1,32 @@
+package org.microbean.helm;
+
+import io.fabric8.kubernetes.client.LocalPortForward;
+import io.grpc.ManagedChannel;
+
+/**
+ * An interface whose implementations create a {@link ManagedChannel} from a
+ * {@link LocalPortForward} to be used to communicate with Tiller.
+ */
+public interface ManagedChannelFactory {
+
+  /**
+   * Creates a {@link ManagedChannel} for communication with Tiller
+   * from the information contained in the supplied {@link
+   * LocalPortForward}.
+   *
+   * <p>This method never returns {@code null}.</p>
+   *
+   * <p>Overrides of this method must not return {@code null}.</p>
+   *
+   * @param portForward a {@link LocalPortForward}; must not be {@code
+   * null}
+   * @return a non-{@code null} {@link ManagedChannel}
+   * @throws NullPointerException if {@code portForward} is {@code
+   * null}
+   * @throws IllegalArgumentException if {@code portForward}'s
+   * {@link LocalPortForward#getLocalAddress()} method returns {@code
+   * null}
+   */
+  ManagedChannel create(final LocalPortForward portForward);
+
+}

--- a/src/main/java/org/microbean/helm/TillerInstaller.java
+++ b/src/main/java/org/microbean/helm/TillerInstaller.java
@@ -999,7 +999,7 @@ public class TillerInstaller {
         throw new TillerPollingDeadlineExceededException(String.valueOf(timeoutInMilliseconds));
       }
       @SuppressWarnings("unchecked")
-      final Tiller tiller = new Tiller((T)this.kubernetesClient, namespace, -1 /* use default */, labels);
+      final Tiller tiller = new Tiller((T)this.kubernetesClient, namespace, -1 /* use default */, labels, new DefaultManagedChannelFactory());
       final HealthBlockingStub health = tiller.getHealthBlockingStub();
       assert health != null;
       final HealthCheckRequest.Builder builder = HealthCheckRequest.newBuilder();


### PR DESCRIPTION
While using this project, I found myself wanting to customize the `ManagedChannel` that was created. While I saw there was an option to override `buildChannel`, I thought it might be nicer to provide that as a dependency to `Tiller` instead. 

As such, I created a `ManagedChannelFactory` interface which is used to create a `ManagedChannel` from a `LocalPortForward`. I also provide the default implementation (`DefaultManagedChannelFactory`) that migrates existing logic from the current `buildChannel` method. It also allows the provision of a `ManagedChannelConfigurer` which is passed the `ManagedChannelBuilder` and is able to manipulate it before it is finally built.

This allows users to do the following if they simply want to configure settings on the `ManagedChannel` instead of having to subclass `Tiller`.

```
final Tiller tiller = new Tiller(client, new DefaultManagedChannelFactory((builder) -> {
    builder
        .keepAliveTime(90L, TimeUnit.SECONDS)
        .keepAliveTimeout(30L, TimeUnit.SECONDS);
}));
```

Let me know if I've not explained anything well, or if you have any concerns or changes you'd like.