### PR TITLE
Ingore empty paths in tar files. Fix regex match for .helmignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 nbactions.xml
 src/site/markdown/*.html
 target/
+/.classpath
+/.project

--- a/src/main/java/org/microbean/helm/chart/HelmIgnorePathMatcher.java
+++ b/src/main/java/org/microbean/helm/chart/HelmIgnorePathMatcher.java
@@ -259,11 +259,11 @@ public class HelmIgnorePathMatcher implements PathMatcher, Predicate<Path> {
                 regex.append("\\.");
                 break;
               case '*':
-                regex.append("[^").append(File.separator).append("]*");
-                break;
+        	  regex.append("[^").append(File.separator).append(File.separator).append("]*");
+        	  break;
               case '?':
-                regex.append("[^").append(File.separator).append("]?");
-                break;
+        	  regex.append("[^").append(File.separator).append(File.separator).append("]?");
+        	  break;
               default:
                 regex.append(c);
                 break;

--- a/src/main/java/org/microbean/helm/chart/HelmIgnorePathMatcher.java
+++ b/src/main/java/org/microbean/helm/chart/HelmIgnorePathMatcher.java
@@ -259,10 +259,10 @@ public class HelmIgnorePathMatcher implements PathMatcher, Predicate<Path> {
                 regex.append("\\.");
                 break;
               case '*':
-        	regex.append("[^").append(File.separator).append(File.separator).append("]*");
+        	regex.append("[^\\\\]*");
         	break;
               case '?':
-        	regex.append("[^").append(File.separator).append(File.separator).append("]?");
+        	regex.append("[^\\\\]?");
         	break;
               default:
                 regex.append(c);

--- a/src/main/java/org/microbean/helm/chart/HelmIgnorePathMatcher.java
+++ b/src/main/java/org/microbean/helm/chart/HelmIgnorePathMatcher.java
@@ -259,11 +259,11 @@ public class HelmIgnorePathMatcher implements PathMatcher, Predicate<Path> {
                 regex.append("\\.");
                 break;
               case '*':
-        	  regex.append("[^").append(File.separator).append(File.separator).append("]*");
-        	  break;
+        	regex.append("[^").append(File.separator).append(File.separator).append("]*");
+        	break;
               case '?':
-        	  regex.append("[^").append(File.separator).append(File.separator).append("]?");
-        	  break;
+        	regex.append("[^").append(File.separator).append(File.separator).append("]?");
+        	break;
               default:
                 regex.append(c);
                 break;

--- a/src/main/java/org/microbean/helm/chart/StreamOrientedChartLoader.java
+++ b/src/main/java/org/microbean/helm/chart/StreamOrientedChartLoader.java
@@ -273,6 +273,10 @@ public abstract class StreamOrientedChartLoader<T> extends AbstractChartLoader<T
     Objects.requireNonNull(chartBuilders);
     Objects.requireNonNull(path);
     Objects.requireNonNull(stream);
+
+    if (path.length() == 0) {
+	return;
+    }
     
     final Chart.Builder builder = getChartBuilder(chartBuilders, path);
     if (builder == null) {


### PR DESCRIPTION
Empty paths in chart tar files cause a null pointer exception. Added code to skip those entries since some published chart archives have this issue. Also, the regex handling for `.helmignore` produces invalid regular expressions because of a slash that is not escaped.